### PR TITLE
Added option to ignore URI parsing errors

### DIFF
--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -248,8 +248,8 @@ namespace Microsoft.OData.Client
         /// With Silverlight, the <paramref name="serviceRoot"/> can be a relative Uri
         /// that will be combined with System.Windows.Browser.HtmlPage.Document.DocumentUri.
         /// </remarks>
-        public DataServiceContext(Uri serviceRoot, ODataProtocolVersion maxProtocolVersion)
-            : this(serviceRoot, maxProtocolVersion, ClientEdmModelCache.GetModel(maxProtocolVersion))
+        public DataServiceContext(Uri serviceRoot, ODataProtocolVersion maxProtocolVersion, bool ignoreUriParsingErrors = false)
+            : this(serviceRoot, maxProtocolVersion, ClientEdmModelCache.GetModel(maxProtocolVersion), ignoreUriParsingErrors)
         {
         }
 
@@ -270,12 +270,12 @@ namespace Microsoft.OData.Client
         /// With Silverlight, the <paramref name="serviceRoot"/> can be a relative Uri
         /// that will be combined with System.Windows.Browser.HtmlPage.Document.DocumentUri.
         /// </remarks>
-        internal DataServiceContext(Uri serviceRoot, ODataProtocolVersion maxProtocolVersion, ClientEdmModel model)
+        internal DataServiceContext(Uri serviceRoot, ODataProtocolVersion maxProtocolVersion, ClientEdmModel model, bool ignoreUriParsingErrors)
         {
             Debug.Assert(model != null, "model != null");
             this.model = model;
 
-            this.baseUriResolver = UriResolver.CreateFromBaseUri(serviceRoot, ServiceRootParameterName);
+            this.baseUriResolver = UriResolver.CreateFromBaseUri(serviceRoot, ServiceRootParameterName, ignoreUriParsingErrors);
             this.maxProtocolVersion = Util.CheckEnumerationValue(maxProtocolVersion, "maxProtocolVersion");
             this.entityParameterSendOption = EntityParameterSendOption.SendFullProperties;
             this.mergeOption = MergeOption.AppendOnly;

--- a/src/Microsoft.OData.Client/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Client/PublicAPI.Unshipped.txt
@@ -355,7 +355,7 @@ Microsoft.OData.Client.DataServiceCollection<T>.LoadNextPartialSetAsync() -> boo
 Microsoft.OData.Client.DataServiceContext
 Microsoft.OData.Client.DataServiceContext.DataServiceContext() -> void
 Microsoft.OData.Client.DataServiceContext.DataServiceContext(System.Uri serviceRoot) -> void
-Microsoft.OData.Client.DataServiceContext.DataServiceContext(System.Uri serviceRoot, Microsoft.OData.Client.ODataProtocolVersion maxProtocolVersion) -> void
+Microsoft.OData.Client.DataServiceContext.DataServiceContext(System.Uri serviceRoot, Microsoft.OData.Client.ODataProtocolVersion maxProtocolVersion, bool ignoreUriParsingErrors = false) -> void
 Microsoft.OData.Client.DataServiceContext.DefaultResolveType(string typeName, string fullNamespace, string languageDependentNamespace) -> System.Type
 Microsoft.OData.Client.DataServiceContext.HttpRequestTransportMode.get -> Microsoft.OData.Client.HttpRequestTransportMode
 Microsoft.OData.Client.DataServiceContext.HttpRequestTransportMode.set -> void

--- a/src/Microsoft.OData.Client/UriResolver.cs
+++ b/src/Microsoft.OData.Client/UriResolver.cs
@@ -70,9 +70,17 @@ namespace Microsoft.OData.Client
         /// <param name="baseUri">The baseUri to use in the UriResolver</param>
         /// <param name="parameterName">The name of the parameter that the user passed the baseUri in from.</param>
         /// <returns>The new UriResolver using the passed in baseUri</returns>
-        internal static UriResolver CreateFromBaseUri(Uri baseUri, string parameterName)
+        internal static UriResolver CreateFromBaseUri(Uri baseUri, string parameterName, bool ignoreUriParsingErrors = false)
         {
-            ConvertToAbsoluteAndValidateBaseUri(ref baseUri, parameterName);
+            if (ignoreUriParsingErrors)
+            {
+                baseUri = ConvertToAbsoluteUri(baseUri);
+            }
+            else
+            {
+                ConvertToAbsoluteAndValidateBaseUri(ref baseUri, parameterName);
+            }
+            
             return new UriResolver(baseUri, null);
         }
 


### PR DESCRIPTION
When initializing a DataServiceContext there was a mandatory URI check
relying on .NETs Uri.IsWellFormedUriString. Sadly there is an active
issue on the .NET side that incorrectly flags URIs like
"http://192.168.0.1:1234/Instance/ODataV4/Company('123-Customer Place
Süd-Ost')/" as being invalid. The progress is tracked here:
https://github.com/dotnet/runtime/issues/21626
To give the user a simple option to prevent this issue from hindering
further development with the library I added a simple bool to ignore
this error.
